### PR TITLE
fix: graphql router image

### DIFF
--- a/server/graphql-router/Dockerfile
+++ b/server/graphql-router/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /rover
 
 RUN unzip bin.zip
 
-FROM ghcr.io/apollographql/router:v1.2.0 as Final
+# FROM ghcr.io/apollographql/router:v1.2.0 as Final
+FROM ghcr.io/ndthanhdev/apollo-router-arm64:v1.1.0 as Final
 
 LABEL org.opencontainers.image.source="https://github.com/ebox-org/ebox"
 
@@ -18,9 +19,8 @@ VOLUME [ "/router/config" ]
 
 WORKDIR /router
 
-COPY --chmod=765 ./server/graphql-router/entrypoint.sh ./entrypoint.sh
-
 COPY ./server/graphql-router/graphql ./graphql
 
-ENTRYPOINT ["/router/entrypoint.sh"]
+COPY --chmod=765 ./server/graphql-router/entrypoint.sh ./entrypoint.sh
 
+ENTRYPOINT ["/router/entrypoint.sh"]

--- a/server/graphql-router/entrypoint.sh
+++ b/server/graphql-router/entrypoint.sh
@@ -8,4 +8,5 @@ export APOLLO_ELV2_LICENSE=accept
 
 cat /router/supergraph.graphql
 
-/dist/router -c /router/config/config.yaml -s /router/supergraph.graphql --hot-reload
+# /dist/router -c /router/config/config.yaml -s /router/supergraph.graphql --hot-reload
+/router/router -c /router/config/config.yaml -s /router/supergraph.graphql --hot-reload


### PR DESCRIPTION
reason:
- can not copy entrypoint.sh due to base image does not support

solution:
- temporary switch to legacy docker image